### PR TITLE
Fix swift nonnull delegate call

### DIFF
--- a/NYTPhotoViewer/NYTPhotosViewController.m
+++ b/NYTPhotoViewer/NYTPhotosViewController.m
@@ -467,7 +467,7 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
         animated = NO;
     }
 
-    NSInteger currentIdx = [self.dataSource indexOfPhoto:self.currentlyDisplayedPhoto];
+    NSInteger currentIdx = self.currentlyDisplayedPhoto != nil ? [self.dataSource indexOfPhoto:self.currentlyDisplayedPhoto] : 0;
     NSInteger newIdx = [self.dataSource indexOfPhoto:viewController.photo];
     UIPageViewControllerNavigationDirection direction = (newIdx < currentIdx) ? UIPageViewControllerNavigationDirectionReverse : UIPageViewControllerNavigationDirectionForward;
     


### PR DESCRIPTION
Fixes a case where the datasource method 
`- (NSInteger)indexOfPhoto:(id <NYTPhoto>)photo` 
was called with a null parameter which resulted in a crash when the dataSource is implemented in swift.