### PR TITLE
use old #import instead of @import

### DIFF
--- a/NYTPhotoViewer/NYTPhotoCaptionView.h
+++ b/NYTPhotoViewer/NYTPhotoCaptionView.h
@@ -6,7 +6,7 @@
 //
 //
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import "NYTPhotoCaptionViewLayoutWidthHinting.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/NYTPhotoViewer/NYTPhotoDismissalInteractionController.h
+++ b/NYTPhotoViewer/NYTPhotoDismissalInteractionController.h
@@ -6,7 +6,7 @@
 //
 //
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/NYTPhotoViewer/NYTPhotoTransitionAnimator.h
+++ b/NYTPhotoViewer/NYTPhotoTransitionAnimator.h
@@ -6,7 +6,7 @@
 //
 //
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/NYTPhotoViewer/NYTPhotoTransitionController.h
+++ b/NYTPhotoViewer/NYTPhotoTransitionController.h
@@ -6,7 +6,7 @@
 //
 //
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/NYTPhotoViewer/NYTPhotoViewController.h
+++ b/NYTPhotoViewer/NYTPhotoViewController.h
@@ -6,7 +6,7 @@
 //
 //
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import "NYTPhotoContainer.h"
 
 @class NYTScalingImageView;

--- a/NYTPhotoViewer/NYTPhotoViewerArrayDataSource.h
+++ b/NYTPhotoViewer/NYTPhotoViewerArrayDataSource.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2017 The New York Times Company. All rights reserved.
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "NYTPhotoViewerDataSource.h"
 

--- a/NYTPhotoViewer/NYTPhotoViewerSinglePhotoDataSource.h
+++ b/NYTPhotoViewer/NYTPhotoViewerSinglePhotoDataSource.h
@@ -6,7 +6,7 @@
 //  Copyright © 2017 The New York Times Company. All rights reserved.
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "NYTPhotoViewerDataSource.h"
 

--- a/NYTPhotoViewer/NYTPhotosOverlayView.h
+++ b/NYTPhotoViewer/NYTPhotosOverlayView.h
@@ -6,7 +6,7 @@
 //
 //
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/NYTPhotoViewer/NYTPhotosViewController.h
+++ b/NYTPhotoViewer/NYTPhotosViewController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 NYTimes. All rights reserved.
 //
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 @class NYTPhotosOverlayView;
 

--- a/NYTPhotoViewer/NYTScalingImageView.h
+++ b/NYTPhotoViewer/NYTScalingImageView.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 The New York Times Company. All rights reserved.
 //
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 #ifdef ANIMATED_GIF_SUPPORT
 @class FLAnimatedImageView;

--- a/NYTPhotoViewer/Protocols/NYTPhoto.h
+++ b/NYTPhotoViewer/Protocols/NYTPhoto.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 NYTimes. All rights reserved.
 //
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/NYTPhotoViewer/Protocols/NYTPhotoCaptionViewLayoutWidthHinting.h
+++ b/NYTPhotoViewer/Protocols/NYTPhotoCaptionViewLayoutWidthHinting.h
@@ -6,8 +6,8 @@
 //
 //
 
-@import Foundation;
-@import UIKit;
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 /**
  *  Allows a view to opt-in to receiving a hint of its layout width. This aids in calculating an appropriate intrinsic content size.

--- a/NYTPhotoViewer/Protocols/NYTPhotoViewerDataSource.h
+++ b/NYTPhotoViewer/Protocols/NYTPhotoViewerDataSource.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 NYTimes. All rights reserved.
 //
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 @protocol NYTPhoto;
 

--- a/NYTPhotoViewer/Resource Loading/NSBundle+NYTPhotoViewer.h
+++ b/NYTPhotoViewer/Resource Loading/NSBundle+NYTPhotoViewer.h
@@ -6,7 +6,7 @@
 //
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @interface NSBundle (NYTPhotoViewer)
 


### PR DESCRIPTION
Fixes a bug where compiling an app which uses objc++ fails.
Module maps are not supported in objc++ therefore use the old `#import` Statements.